### PR TITLE
fix: omnipath adpater/mapping [networks.yaml] map: -> replace: for extra_attrs and evidences | schema curation_effort: int -> curation_effort: str for edge inhibition & stimulation

### DIFF
--- a/config/schema_config.yaml
+++ b/config/schema_config.yaml
@@ -179,7 +179,7 @@ stimulation:
         dorothea_coexp: bool
         dorothea_level: str
         type: str
-        curation_effort: int
+        curation_effort: str
         extra_attrs: str
         evidences: str
 
@@ -212,7 +212,7 @@ inhibition:
         dorothea_coexp: bool
         dorothea_level: str
         type: str
-        curation_effort: int
+        curation_effort: str
         extra_attrs: str
         evidences: str
 

--- a/src/omnipath_secondary_adapter/adapters/networks.yaml
+++ b/src/omnipath_secondary_adapter/adapters/networks.yaml
@@ -293,19 +293,21 @@ transformers:
             - undirected_molecular_interaction
             - stimulation
             - inhibition
-    - map:
+    - replace:
         column: extra_attrs
         to_property: extra_attrs
         for_objects:
             - undirected_molecular_interaction
             - stimulation
             - inhibition
-    - map:
+        forbidden: "'"
+    - replace:
         column: evidences
         to_property: evidences
         for_objects:
             - undirected_molecular_interaction
             - stimulation
             - inhibition
+        forbidden: "'"
 metadata:
         - data_source: omnipath_networks


### PR DESCRIPTION
Fix omnipath adapter for `extra_attrs` and `evidences` :
Old transformer `map:` | New transformer `replace:` with `forbidden: " ' " `